### PR TITLE
Upgrade `@actions/github` dependency from 2.1.1 to 2.2.0 to support GitHub Enterprise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "team-sync",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/github": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.1.tgz",
-      "integrity": "sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.2.0.tgz",
+      "integrity": "sha512-9UAZqn8ywdR70n3GwVle4N8ALosQs4z50N7XMXrSTUVOmVpaBC5kE3TRTT7qQdi3OaQV24mjGuJZsHUmhD+ZXw==",
       "requires": {
         "@actions/http-client": "^1.0.3",
         "@octokit/graphql": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team-sync",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "private": true,
   "description": "GitHub action to synchronize GitHub Teams with the contents of a teams document",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.6",
-    "@actions/github": "^2.1.1",
+    "@actions/github": "^2.2.0",
     "@octokit/rest": "^16.43.1",
     "@sindresorhus/slugify": "^0.11.0",
     "@types/js-yaml": "^3.12.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "team-sync",
   "version": "0.1.0",
   "private": true,
-  "description": "GitHub action to sync ynchronize GitHub Teams with the contents of a teams document",
+  "description": "GitHub action to synchronize GitHub Teams with the contents of a teams document",
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
GitHub Enterprise Server support was added to `@actions/github` in version 2.2.0:
https://github.com/actions/toolkit/blob/264e52add636fd679299bc3d61c6e0fa0a35c7d7/packages/github/RELEASES.md#220
(Diff: https://github.com/actions/toolkit/commit/264e52add636fd679299bc3d61c6e0fa0a35c7d7)
so upgrading will allow the team-sync action to support GitHub Enterprise

(Also fixed the `name` and `description` properties in `package.json`)